### PR TITLE
[修复]NULL报错问题

### DIFF
--- a/multi_timer.h
+++ b/multi_timer.h
@@ -7,6 +7,7 @@
 #define _MULTI_TIMER_H_
 
 #include "stdint.h"
+#include "stddef.h"
 
 typedef struct Timer {
     uint32_t timeout;


### PR DESCRIPTION
大佬好，我是Mculover666.

MultiTimer移植进STM32工程时，默认情况下multi_timer.c中NULL宏定义会出错，如图：
![image](https://user-images.githubusercontent.com/30443637/80669442-071a7e80-8ad7-11ea-8bf4-273f66220938.png)
